### PR TITLE
Graceful Shutdown + TTY Support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Windows CRLF => Linux LF
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses=MIT
 # Use noninteractive mode to avoid prompts during package installation
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt -y upgrade \
-	&& apt -y install libreadline-dev libncurses-dev libmysqlclient-dev unzip wget \
+	&& apt -y install libreadline-dev libncurses-dev libmysqlclient-dev unzip wget netcat-openbsd \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download libssl1.1 library for different architectures
@@ -54,6 +54,9 @@ EXPOSE 22003/udp 22005/tcp 22126/udp
 
 # Expose volumes for shared data
 VOLUME ["/src/shared-config", "/src/shared-modules", "/src/shared-resources", "/src/shared-http-cache", "/src/shared-databases"]
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+	CMD nc -z -u 127.0.0.1 22003 || exit 1
 
 # Set the entrypoint
 ENTRYPOINT ["/src/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses=MIT
 # Use noninteractive mode to avoid prompts during package installation
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt -y upgrade \
-	&& apt -y install libreadline-dev libncurses-dev libmysqlclient-dev unzip wget netcat-openbsd \
+	&& apt -y install libreadline-dev libncurses-dev libmysqlclient-dev unzip wget netcat-openbsd dumb-init \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download libssl1.1 library for different architectures
@@ -59,7 +59,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
 	CMD nc -z -u 127.0.0.1 22003 || exit 1
 
 # Set the entrypoint
-ENTRYPOINT ["/src/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/src/entrypoint.sh"]
 
 # When that's done, run the server
 CMD ["/src/run.sh"]

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ services:
 
 Customize the container by setting these environment variables:
 
-|           Variable            | Default Value |                       Comment                        |
-| :---------------------------: | :-----------: | :--------------------------------------------------: |
-| **INSTALL_DEFAULT_RESOURCES** |     true      | Downloads default resources from the MTA:SA mirror.  |
-|   **INSTALL_NIGHTLY_BUILD**   |     false     | Downloads the latest nightly build of MTA:SA server. |
+|           Variable            | Default Value |                       Comment                             |
+| :---------------------------: | :-----------: | :-------------------------------------------------------: |
+| **INSTALL_DEFAULT_RESOURCES** |     true      |    Downloads default resources from the MTA:SA mirror.    |
+|   **INSTALL_NIGHTLY_BUILD**   |     false     |    Downloads the latest nightly build of MTA:SA server.   |
+|   **SERVER_STOP_DELAY**       |      10       | Time (seconds) to wait for server to shutdown gracefully. |
 
 ### Platform Support Notice
 


### PR DESCRIPTION
Hey, this PR gets the image setup running smoother with proper shutdowns and better reliability.

## What's in it:
- Normalized shell scripts to use LF line endings for consistency.
- Added `netcat-openbsd` and a health check to monitor game server UDP port `22003`.
- Added `dumb-init` for proper PID 1 signal handling which helps ensure server gets cleaned up always.
- Added graceful shutdown support for `docker stop`, Ctrl+C when attached, and TTY `shutdown` commands.
- Introduced `SERVER_STOP_DELAY` variable to tweak shutdown timing and avoid abrupt kills.