### PR TITLE
Fix server stdin handling and config persistence

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,11 +48,12 @@ check_config() {
         || { echo "Failed to download or extract baseconfig"; exit 1; }
     fi
 
-    # Replace server config files with the ones in shared-config
+    # Link server config files with the ones in shared-config
     for file in shared-config/*; do
         if [ -f "${file}" ]; then
             fileName=$(basename "$file")
-            cp -f "${file}" "multitheftauto_linux${ARCH_TYPE}/mods/deathmatch/${fileName}"
+            rm -f "multitheftauto_linux${ARCH_TYPE}/mods/deathmatch/${fileName}"
+            ln -s "${BASE_DIR}/shared-config/${fileName}" "multitheftauto_linux${ARCH_TYPE}/mods/deathmatch/${fileName}"
         fi
     done
 }

--- a/run.sh
+++ b/run.sh
@@ -34,21 +34,6 @@ get_executable_name() {
     esac
 }
 
-save_config() {
-    echo "Saving config files.."
-
-    if [ ! -d "shared-config" ]; then
-        mkdir -p shared-config
-    fi
-
-    # Save server config files to shared-config
-    for file in acl.xml mtaserver.conf vehiclecolors.conf server-id.keys banlist.xml settings.xml; do
-        if [ -f "multitheftauto_linux${ARCH_TYPE}/mods/deathmatch/${file}" ]; then
-            cp -f "multitheftauto_linux${ARCH_TYPE}/mods/deathmatch/${file}" shared-config/
-        fi
-    done
-}
-
 save_databases() {
     echo "Saving databases.."
 
@@ -101,7 +86,6 @@ main() {
 
 
 save_data() {
-    save_config
     save_databases
 }
 


### PR DESCRIPTION
This PR fixes a couple of annoying issues we've been having with the MTA server container, especially around input
handling and config management.
   
# The Problem
  The container had some frustrating quirks:
  - After running for a while, typing commands would just stop working randomly
  - Config changes required restarting the container to take effect
  - Server shutdowns were slow and not very reliable
  
# What's Changed

  **Improved input handling** - Fixed issue where commands would randomly stop working in long-running containers by
   implementing a FIFO pipe system for reliable stdin forwarding.

  **Real-time config persistence** - Replaced config file copying with symlinks so configuration changes are
  reflected immediately without container restarts. (#3)

  **Enhanced shutdown reliability** - Server shutdown now waits for actual process exit instead of fixed delays,
  improving responsiveness.
